### PR TITLE
Fix bug for checking motif mappings exist

### DIFF
--- a/workflows/miniac_gw.nf
+++ b/workflows/miniac_gw.nf
@@ -285,6 +285,9 @@ workflow genome_wide_miniac {
     Genes_metadata
 
     main:
+    
+    if (!file(MotMapsFile_gw).exists()) { error "Please make sure that you downloaded the motif mapping files as described in the documentation." }
+    
     ACR_files = Channel.fromPath("${ACR_dir}/*.bed").ifEmpty { error "No *.bed files could be found in the specified ACR directory ${ACR_dir}" }
     
     get_ACR_shufflings(ACR_files, Faix_file, Non_cod_genome)    
@@ -294,7 +297,7 @@ workflow genome_wide_miniac {
     parsed_acr = get_ACR_shufflings.out.acr_input
                                         .map {n -> [n.baseName.split("_")[0..-2].join("_"), n]}
 
-    motmaps_ch = Channel.fromPath(MotMapsFile_gw).ifEmpty { error "There was an error downloading the motif mapping files ${MotMapsFile_gw}" }
+    motmaps_ch = Channel.fromPath(MotMapsFile_gw)
 
     input_stats = acr_shufflings_ch.combine(motmaps_ch)
 

--- a/workflows/miniac_lb.nf
+++ b/workflows/miniac_lb.nf
@@ -283,6 +283,9 @@ workflow locus_based_miniac {
     Genes_metadata
 
     main:
+
+    if (!file(MotMapsFile_lb).exists()) { error "Please make sure that you downloaded the motif mapping files as described in the documentation." }
+
     ACR_files = Channel.fromPath("${ACR_dir}/*.bed").ifEmpty { error "No *.bed files could be found in the specified ACR directory ${ACR_dir}" }
     
     get_ACR_shufflings(ACR_files, Faix_file, Promoter_file)    
@@ -292,7 +295,7 @@ workflow locus_based_miniac {
     parsed_acr = get_ACR_shufflings.out.acr_input
                                         .map {n -> [n.baseName.split("_")[0..-2].join("_"), n]}
 
-    motmaps_ch = Channel.fromPath(MotMapsFile_lb).ifEmpty { error "There was an error downloading the motif mapping files ${MotMapsFile_lb}" }
+    motmaps_ch = Channel.fromPath(MotMapsFile_lb)
 
     input_stats = acr_shufflings_ch.combine(motmaps_ch)
 


### PR DESCRIPTION
Originally, to check that the motif mappings had been downloaded, I used ifEmpty method on the channel, but the channel had the string of the path in it, so it was not empty, and therefore the pipeline would run without an actual motif mapping file. Also, this check was after the "acr shuffling" process, while it should be in the beggning. We added the actual check for the file existence at the beggning of the workflow, both for genome-wide and locus-based workflows. Closes #4 