### PR TITLE
Feature/updated actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
     
     - name: Check versions
       run: |
-        java -version
         nextflow info
 
     - name: Run nf-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
         curl -k -L -o data/ath/ath_genome_wide_motif_mappings.bed https://ftp.psb.ugent.be/pub/software/mini_ac/test_files/ath_genome_wide_motif_mappings.bed
         curl -k -L -o data/ath/ath_locus_based_motif_mappings_5kbup_1kbdown.bed https://ftp.psb.ugent.be/pub/software/mini_ac/test_files/ath_locus_based_motif_mappings_5kbup_1kbdown.bed
 
-    - name: Disable container awareness
-      run: export NXF_OPTS='-XX:-UseContainerSupport'
+        #- name: Disable container awareness
+        #run: export NXF_OPTS='-XX:-UseContainerSupport'
     
     - name: Check versions
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
 
     - name: Disable container awareness
       run: export NXF_OPTS='-XX:-UseContainerSupport'
+    
+    - name: Check versions
+      run: java -version
+          nextflow info
 
     - name: Run nf-test
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,9 @@ jobs:
       run: java -version
 
     - name: Setup Nextflow
-      uses: nf-core/setup-nextflow@v1.3.0
+      uses: nf-core/setup-nextflow@v1
+      with:
+        version: "21.10.6"
 
     - name: Setup nf-test
       run: wget -qO- https://code.askimed.com/install/nf-test | bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,6 @@ jobs:
     - uses: nf-core/setup-nf-test@v1
       with:
         version: 0.9.5
-          #- name: Setup nf-test
-          #run: wget -qO- https://code.askimed.com/install/nf-test | bash
 
     - name: Fetch motif mapping files
       run: |
@@ -44,9 +42,6 @@ jobs:
         curl -k -L -o data/ath/ath_genome_wide_motif_mappings.bed https://ftp.psb.ugent.be/pub/software/mini_ac/test_files/ath_genome_wide_motif_mappings.bed
         curl -k -L -o data/ath/ath_locus_based_motif_mappings_5kbup_1kbdown.bed https://ftp.psb.ugent.be/pub/software/mini_ac/test_files/ath_locus_based_motif_mappings_5kbup_1kbdown.bed
 
-        #- name: Disable container awareness
-        #run: export NXF_OPTS='-XX:-UseContainerSupport'
-    
     - name: Check versions
       run: |
         nextflow info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,4 @@ jobs:
 
     - name: Run nf-test
       shell: bash
-      run: ./nf-test test
+      run: nf-test test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,6 @@ jobs:
 
     - name: Setup Nextflow
       uses: nf-core/setup-nextflow@v1
-      with:
-        version: "21.10.6"
 
     - name: Setup nf-test
       run: wget -qO- https://code.askimed.com/install/nf-test | bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
         curl -k -L -o data/ath/ath_genome_wide_motif_mappings.bed https://ftp.psb.ugent.be/pub/software/mini_ac/test_files/ath_genome_wide_motif_mappings.bed
         curl -k -L -o data/ath/ath_locus_based_motif_mappings_5kbup_1kbdown.bed https://ftp.psb.ugent.be/pub/software/mini_ac/test_files/ath_locus_based_motif_mappings_5kbup_1kbdown.bed
 
+    - name: Disable container awareness
+      run: export NXF_OPTS='-XX:-UseContainerSupport'
+
     - name: Run nf-test
       shell: bash
       run: ./nf-test test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,14 @@ jobs:
 
     - name: Setup Nextflow
       uses: nf-core/setup-nextflow@v1
-
-    - name: Setup nf-test
-      run: wget -qO- https://code.askimed.com/install/nf-test | bash
+      with:
+        version: 25.10.4
+    
+    - uses: nf-core/setup-nf-test@v1
+      with:
+        version: 0.9.5
+          #- name: Setup nf-test
+          #run: wget -qO- https://code.askimed.com/install/nf-test | bash
 
     - name: Fetch motif mapping files
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: oracle
-        java-version: 17
+        java-version: 25
     
     - name: Check Java version
       run: java -version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,9 @@ jobs:
       run: export NXF_OPTS='-XX:-UseContainerSupport'
     
     - name: Check versions
-      run: java -version
-          nextflow info
+      run: |
+        java -version
+        nextflow info
 
     - name: Run nf-test
       shell: bash

--- a/tests/mini_ac.nf.test.snap
+++ b/tests/mini_ac.nf.test.snap
@@ -4,8 +4,8 @@
             null,
             0,
             {
+		"tasksCount": 10,
                 "tasksFailed": 0,
-                "tasksCount": 10,
                 "tasksSucceeded": 10
             },
             [
@@ -40,8 +40,8 @@
             null,
             0,
             {
-                "tasksFailed": 0,
                 "tasksCount": 10,
+		"tasksFailed": 0,
                 "tasksSucceeded": 10
             },
             [
@@ -76,8 +76,8 @@
             null,
             0,
             {
+		"tasksCount": 12,
                 "tasksFailed": 0,
-                "tasksCount": 12,
                 "tasksSucceeded": 12
             },
             [
@@ -114,8 +114,8 @@
             null,
             0,
             {
+		"tasksCount": 12,
                 "tasksFailed": 0,
-                "tasksCount": 12,
                 "tasksSucceeded": 12
             },
             [


### PR DESCRIPTION
The snapshot did no longer match the output, due to the change in order of the trace metrics. As the versions of nextflow and nf-test were not fixed, this could have been the cause. 

In this pull request, Nextflow is fixed to version to 25.10.4 and nf-test to 0.9.5. The snapshot was adapted to match the new order of output.